### PR TITLE
Updated for tidy csv output + more retries if no broadcast detected

### DIFF
--- a/read_waveplus.py
+++ b/read_waveplus.py
@@ -83,7 +83,7 @@ if Mode == 'file':
 
 SerialNumbers = sys.argv[1]
 SamplePeriod = int(sys.argv[2])
-MaxRetries = 100
+MaxRetries = 10
 
 # ====================================
 # Utility functions for WavePlus class
@@ -270,7 +270,7 @@ try:
                 VOC_lvl = str(sensors.getValue(SENSOR_IDX_VOC_LVL))
 
                 # Print data
-                data = [datetime.datetime.now(), str(waveplus.SN), humidity,
+                data = [datetime.today().isoformat(sep=' ', timespec='seconds'), str(waveplus.SN), humidity,
                         radon_st_avg, radon_lt_avg, temperature, pressure, CO2_lvl, VOC_lvl]
 
                 if (Mode == 'terminal'):

--- a/read_waveplus.py
+++ b/read_waveplus.py
@@ -232,7 +232,7 @@ try:
     header = ['Timestamp', 'SN', 'Humidity', 'Radon ST avg',
               'Radon LT avg', 'Temperature', 'Pressure', 'CO2 level', 'VOC level']
 
-    headunits = ["datetime", "%rH", "Bq/m3", "Bq/m3", "degC", "hPa", "ppm", "ppb"]
+    headunits = ["datetime", "Integer", "%rH", "Bq/m3", "Bq/m3", "degC", "hPa", "ppm", "ppb"]
 
     if (Mode == 'terminal'):
         print(tableprint.header(header, width=12))

--- a/read_waveplus.py
+++ b/read_waveplus.py
@@ -83,7 +83,7 @@ if Mode == 'file':
 
 SerialNumbers = sys.argv[1]
 SamplePeriod = int(sys.argv[2])
-MaxRetries = 10
+MaxRetries = 100
 
 # ====================================
 # Utility functions for WavePlus class
@@ -270,7 +270,7 @@ try:
                 VOC_lvl = str(sensors.getValue(SENSOR_IDX_VOC_LVL))
 
                 # Print data
-                data = [datetime.today().isoformat(sep=' ', timespec='seconds'), str(waveplus.SN), humidity,
+                data = [datetime.today().isoformat(sep=' '), str(waveplus.SN), humidity,
                         radon_st_avg, radon_lt_avg, temperature, pressure, CO2_lvl, VOC_lvl]
 
                 if (Mode == 'terminal'):

--- a/read_waveplus.py
+++ b/read_waveplus.py
@@ -229,9 +229,10 @@ try:
 
     # print "Device serial number: %s" %(SerialNumber)
 
-    header = [['Timestamp', 'SN', 'Humidity', 'Radon ST avg',
-              'Radon LT avg', 'Temperature', 'Pressure', 'CO2 level', 'VOC level'\n
-               "datetime", "%rH", "Bq/m3", "Bq/m3", "degC", "hPa", "ppm", "ppb"]]
+    header = ['Timestamp', 'SN', 'Humidity', 'Radon ST avg',
+              'Radon LT avg', 'Temperature', 'Pressure', 'CO2 level', 'VOC level']
+
+    headunits = ["datetime", "%rH", "Bq/m3", "Bq/m3", "degC", "hPa", "ppm", "ppb"]
 
     if (Mode == 'terminal'):
         print(tableprint.header(header, width=12))
@@ -240,6 +241,7 @@ try:
     elif (Mode == 'file'):
         file = open(outfile, 'a+')
         file.write(','.join(header) + "\n")
+        file.write(','.join(headunits) + "\n")
         file.close()
 
     while True:

--- a/read_waveplus.py
+++ b/read_waveplus.py
@@ -83,7 +83,7 @@ if Mode == 'file':
 
 SerialNumbers = sys.argv[1]
 SamplePeriod = int(sys.argv[2])
-MaxRetries = 10
+MaxRetries = 100
 
 # ====================================
 # Utility functions for WavePlus class
@@ -229,8 +229,15 @@ try:
 
     # print "Device serial number: %s" %(SerialNumber)
 
-    header = ['Timestamp', 'SN', 'Humidity', 'Radon ST avg',
-              'Radon LT avg', 'Temperature', 'Pressure', 'CO2 level', 'VOC level']
+    header = [['Timestamp', 'SN', 'Humidity', 'Radon ST avg',
+              'Radon LT avg', 'Temperature', 'Pressure', 'CO2 level', 'VOC level'],
+              [ str(sensors.getUnit(SENSOR_IDX_HUMIDITY)), 
+                str(sensors.getUnit(SENSOR_IDX_RADON_SHORT_TERM_AVG)),
+                str(sensors.getUnit(SENSOR_IDX_RADON_LONG_TERM_AVG)),
+                str(sensors.getUnit(SENSOR_IDX_TEMPERATURE)),
+                str(sensors.getUnit(SENSOR_IDX_REL_ATM_PRESSURE)),
+                str(sensors.getUnit(SENSOR_IDX_CO2_LVL)),
+                str(sensors.getUnit(SENSOR_IDX_VOC_LVL)) ]]
 
     if (Mode == 'terminal'):
         print(tableprint.header(header, width=12))
@@ -261,20 +268,13 @@ try:
                 sensors = waveplus.read()
 
                 # extract
-                humidity = str(sensors.getValue(SENSOR_IDX_HUMIDITY)) + \
-                    " " + str(sensors.getUnit(SENSOR_IDX_HUMIDITY))
-                radon_st_avg = str(sensors.getValue(SENSOR_IDX_RADON_SHORT_TERM_AVG)) + \
-                    " " + str(sensors.getUnit(SENSOR_IDX_RADON_SHORT_TERM_AVG))
-                radon_lt_avg = str(sensors.getValue(SENSOR_IDX_RADON_LONG_TERM_AVG)) + \
-                    " " + str(sensors.getUnit(SENSOR_IDX_RADON_LONG_TERM_AVG))
-                temperature = str(sensors.getValue(
-                    SENSOR_IDX_TEMPERATURE)) + " " + str(sensors.getUnit(SENSOR_IDX_TEMPERATURE))
-                pressure = str(sensors.getValue(SENSOR_IDX_REL_ATM_PRESSURE)) + \
-                    " " + str(sensors.getUnit(SENSOR_IDX_REL_ATM_PRESSURE))
-                CO2_lvl = str(sensors.getValue(SENSOR_IDX_CO2_LVL)) + \
-                    " " + str(sensors.getUnit(SENSOR_IDX_CO2_LVL))
-                VOC_lvl = str(sensors.getValue(SENSOR_IDX_VOC_LVL)) + \
-                    " " + str(sensors.getUnit(SENSOR_IDX_VOC_LVL))
+                humidity = str(sensors.getValue(SENSOR_IDX_HUMIDITY))
+                radon_st_avg = str(sensors.getValue(SENSOR_IDX_RADON_SHORT_TERM_AVG))
+                radon_lt_avg = str(sensors.getValue(SENSOR_IDX_RADON_LONG_TERM_AVG))
+                temperature = str(sensors.getValue(SENSOR_IDX_TEMPERATURE))
+                pressure = str(sensors.getValue(SENSOR_IDX_REL_ATM_PRESSURE))
+                CO2_lvl = str(sensors.getValue(SENSOR_IDX_CO2_LVL))
+                VOC_lvl = str(sensors.getValue(SENSOR_IDX_VOC_LVL))
 
                 # Print data
                 data = [datetime.today().isoformat(), str(waveplus.SN), humidity,

--- a/read_waveplus.py
+++ b/read_waveplus.py
@@ -230,8 +230,8 @@ try:
     # print "Device serial number: %s" %(SerialNumber)
 
     header = [['Timestamp', 'SN', 'Humidity', 'Radon ST avg',
-              'Radon LT avg', 'Temperature', 'Pressure', 'CO2 level', 'VOC level'],
-              ["%rH", "Bq/m3", "Bq/m3", "degC", "hPa", "ppm", "ppb"]]
+              'Radon LT avg', 'Temperature', 'Pressure', 'CO2 level', 'VOC level'\n
+               "datetime", "%rH", "Bq/m3", "Bq/m3", "degC", "hPa", "ppm", "ppb"]]
 
     if (Mode == 'terminal'):
         print(tableprint.header(header, width=12))

--- a/read_waveplus.py
+++ b/read_waveplus.py
@@ -231,13 +231,7 @@ try:
 
     header = [['Timestamp', 'SN', 'Humidity', 'Radon ST avg',
               'Radon LT avg', 'Temperature', 'Pressure', 'CO2 level', 'VOC level'],
-              [ str(sensors.getUnit(SENSOR_IDX_HUMIDITY)), 
-                str(sensors.getUnit(SENSOR_IDX_RADON_SHORT_TERM_AVG)),
-                str(sensors.getUnit(SENSOR_IDX_RADON_LONG_TERM_AVG)),
-                str(sensors.getUnit(SENSOR_IDX_TEMPERATURE)),
-                str(sensors.getUnit(SENSOR_IDX_REL_ATM_PRESSURE)),
-                str(sensors.getUnit(SENSOR_IDX_CO2_LVL)),
-                str(sensors.getUnit(SENSOR_IDX_VOC_LVL)) ]]
+              ["%rH", "Bq/m3", "Bq/m3", "degC", "hPa", "ppm", "ppb"]]
 
     if (Mode == 'terminal'):
         print(tableprint.header(header, width=12))

--- a/read_waveplus.py
+++ b/read_waveplus.py
@@ -229,10 +229,8 @@ try:
 
     # print "Device serial number: %s" %(SerialNumber)
 
-    header = ['Timestamp', 'SN', 'Humidity', 'Radon ST avg',
-              'Radon LT avg', 'Temperature', 'Pressure', 'CO2 level', 'VOC level']
-
-    headunits = ["datetime", "Integer", "%rH", "Bq/m3", "Bq/m3", "degC", "hPa", "ppm", "ppb"]
+    header = ['Timestamp', 'Sensor Serial Number', 'Humidity - %rH', 'Radon ST avg - Bq/m3',
+              'Radon LT avg - Bq/m3', 'Temperature - degC', 'Pressure - hPa', 'CO2 level - ppm', 'VOC level - ppb']
 
     if (Mode == 'terminal'):
         print(tableprint.header(header, width=12))
@@ -241,7 +239,6 @@ try:
     elif (Mode == 'file'):
         file = open(outfile, 'a+')
         file.write(','.join(header) + "\n")
-        file.write(','.join(headunits) + "\n")
         file.close()
 
     while True:
@@ -273,7 +270,7 @@ try:
                 VOC_lvl = str(sensors.getValue(SENSOR_IDX_VOC_LVL))
 
                 # Print data
-                data = [datetime.today().isoformat(), str(waveplus.SN), humidity,
+                data = [datetime.datetime.now(), str(waveplus.SN), humidity,
                         radon_st_avg, radon_lt_avg, temperature, pressure, CO2_lvl, VOC_lvl]
 
                 if (Mode == 'terminal'):

--- a/read_waveplus.py
+++ b/read_waveplus.py
@@ -230,7 +230,7 @@ try:
     # print "Device serial number: %s" %(SerialNumber)
 
     header = ['Timestamp', 'Sensor Serial Number', 'Humidity - %rH', 'Radon ST avg - Bq/m3',
-              'Radon LT avg - Bq/m3', 'Temperature - degC', 'Pressure - hPa', 'CO2 level - ppm', 'VOC level - ppb']
+              'Radon LT avg - Bq/m3', 'T - degC', 'P - hPa', 'CO2 - ppm', 'VOC - ppb']
 
     if (Mode == 'terminal'):
         print(tableprint.header(header, width=12))


### PR DESCRIPTION


1) For the argument "file", changed output file format to be more concise. Reformatted the output table to a tidy csv ready for import. The first line contains names, the second line units and the following lines contain the numeric values only.

2) Instead of 10 retries, 100 retries are done before exiting if no broadvcast detected.